### PR TITLE
[ERICK-68] Remove Double Swipe Right Dial Binds from Shared Logic from Android and iOS

### DIFF
--- a/android/app/src/main/java/com/vatoo/erick/MyInputMethodService.kt
+++ b/android/app/src/main/java/com/vatoo/erick/MyInputMethodService.kt
@@ -8,38 +8,22 @@ import android.view.inputmethod.EditorInfo
 import com.vatoo.erick.shared.InputAction
 import com.vatoo.erick.shared.KeyboardActionDelegate
 import com.vatoo.erick.shared.KeyboardStateMachine
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import android.content.Intent
 import android.widget.ImageButton
-
-// 注意：如果报红，请使用 Alt+Enter 导入你在 Shared 模块中写的类 (InputAction, KeyboardStateMachine 等)
 
 class MyInputMethodService : InputMethodService(), KeyboardActionDelegate {
 
     private lateinit var leftJoystick: JoystickView
     private lateinit var rightJoystick: JoystickView
 
-    // --- 协程生命周期管理 ---
-    // 必须给状态机提供一个作用域，当输入法关闭时，销毁所有倒计时任务防止内存泄漏
-    private val serviceJob = SupervisorJob()
-    private val serviceScope = CoroutineScope(Dispatchers.Main + serviceJob)
-
-    // 引入我们在 Shared 模块里写的跨平台大脑
     private lateinit var stateMachine: KeyboardStateMachine
 
     override fun onCreate() {
         super.onCreate()
-        // 输入法创建时，组装大脑，并把自己 (this) 作为代理传进去
-        stateMachine = KeyboardStateMachine(this, serviceScope)
+        stateMachine = KeyboardStateMachine(this)
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        serviceJob.cancel() // 输入法销毁时，清理所有的协程定时器
-    }
+    // onDestroy() needs no override — no coroutine scope to cancel anymore
 
     override fun onCreateInputView(): View {
         val view = layoutInflater.inflate(R.layout.keyboard_simple, null)
@@ -59,7 +43,7 @@ class MyInputMethodService : InputMethodService(), KeyboardActionDelegate {
             dispatchTouchToStateMachine(event, isLeft = false, joystick = rightJoystick)
             true
         }
-        //Setting
+
         val settingsBtn = view.findViewById<ImageButton>(R.id.btn_settings)
         settingsBtn?.setOnClickListener {
             val intent = Intent(this, SettingsActivity::class.java).apply {
@@ -71,9 +55,7 @@ class MyInputMethodService : InputMethodService(), KeyboardActionDelegate {
         return view
     }
 
-    // --- 核心：将 Android 触摸事件翻译并喂给大脑 ---
     private fun dispatchTouchToStateMachine(event: MotionEvent, isLeft: Boolean, joystick: JoystickView) {
-        // 计算相对于圆心的偏移量
         val dx = event.x - (joystick.width / 2f)
         val dy = event.y - (joystick.height / 2f)
 
@@ -81,46 +63,37 @@ class MyInputMethodService : InputMethodService(), KeyboardActionDelegate {
         val isDownOrMove = actionMasked == MotionEvent.ACTION_DOWN || actionMasked == MotionEvent.ACTION_MOVE
         val isUpOrCancel = actionMasked == MotionEvent.ACTION_UP || actionMasked == MotionEvent.ACTION_CANCEL
 
-        // 1. 更新纯粹的 UI 渲染
         if (isDownOrMove) {
             joystick.updateThumb(dx, dy)
         } else if (isUpOrCancel) {
             joystick.resetThumb()
         }
 
-        // 2. 将数据喂给跨平台状态机 (它不需要知道什么是 MotionEvent)
         stateMachine.handleTouch(dx, dy, isLeft, isDownOrMove, isUpOrCancel)
-
-        // 3. 从状态机获取结果，更新预览 UI
         rightJoystick.setPreviewText(stateMachine.getPreviewText())
     }
-
-    // ==========================================
-    // 实现 KeyboardActionDelegate 接口 (接收大脑的命令并执行)
-    // ==========================================
 
     override fun commitText(text: String) {
         currentInputConnection?.commitText(text, 1)
     }
 
     override fun sendInputAction(action: InputAction) {
-        // 将跨平台的 InputAction 翻译成 Android 原生的 KeyEvent
         val keyCode = when (action) {
-            InputAction.SPACE -> KeyEvent.KEYCODE_SPACE
-            InputAction.ENTER -> KeyEvent.KEYCODE_ENTER
-            InputAction.BACKSPACE -> KeyEvent.KEYCODE_DEL
+            InputAction.SPACE          -> KeyEvent.KEYCODE_SPACE
+            InputAction.ENTER          -> KeyEvent.KEYCODE_ENTER
+            InputAction.BACKSPACE      -> KeyEvent.KEYCODE_DEL
+            InputAction.MOVE_HOME      -> KeyEvent.KEYCODE_MOVE_HOME
+            InputAction.MOVE_END       -> KeyEvent.KEYCODE_MOVE_END
+            InputAction.TOGGLE_SHIFT,
+            InputAction.TOGGLE_CAPS    -> -1
             InputAction.DELETE_FORWARD -> KeyEvent.KEYCODE_FORWARD_DEL
-            InputAction.MOVE_HOME -> KeyEvent.KEYCODE_MOVE_HOME
-            InputAction.MOVE_END -> KeyEvent.KEYCODE_MOVE_END
-            InputAction.DPAD_UP -> KeyEvent.KEYCODE_DPAD_UP
-            InputAction.DPAD_DOWN -> KeyEvent.KEYCODE_DPAD_DOWN
-            InputAction.DPAD_LEFT -> KeyEvent.KEYCODE_DPAD_LEFT
-            InputAction.DPAD_RIGHT -> KeyEvent.KEYCODE_DPAD_RIGHT
-            InputAction.PAGE_UP -> KeyEvent.KEYCODE_PAGE_UP
-            InputAction.PAGE_DOWN -> KeyEvent.KEYCODE_PAGE_DOWN
-            InputAction.TAB -> KeyEvent.KEYCODE_TAB
-            // 大小写切换已经在状态机内部消化，无需在这里处理
-            InputAction.TOGGLE_SHIFT, InputAction.TOGGLE_CAPS -> -1
+            InputAction.DPAD_UP        -> KeyEvent.KEYCODE_DPAD_UP
+            InputAction.DPAD_DOWN      -> KeyEvent.KEYCODE_DPAD_DOWN
+            InputAction.DPAD_LEFT      -> KeyEvent.KEYCODE_DPAD_LEFT
+            InputAction.DPAD_RIGHT     -> KeyEvent.KEYCODE_DPAD_RIGHT
+            InputAction.PAGE_UP        -> KeyEvent.KEYCODE_PAGE_UP
+            InputAction.PAGE_DOWN      -> KeyEvent.KEYCODE_PAGE_DOWN
+            InputAction.TAB            -> KeyEvent.KEYCODE_TAB
         }
 
         if (keyCode != -1) {
@@ -129,7 +102,6 @@ class MyInputMethodService : InputMethodService(), KeyboardActionDelegate {
         }
     }
 
-    // --- 彻底禁止全屏的"四重防火墙" (保持不变) ---
     override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
         attribute?.let { it.imeOptions = it.imeOptions or EditorInfo.IME_FLAG_NO_EXTRACT_UI }
         super.onStartInput(attribute, restarting)
@@ -144,6 +116,4 @@ class MyInputMethodService : InputMethodService(), KeyboardActionDelegate {
         super.onEvaluateInputViewShown()
         return true
     }
-
-
 }

--- a/android/shared/src/commonMain/kotlin/KeyboardContracts.kt
+++ b/android/shared/src/commonMain/kotlin/KeyboardContracts.kt
@@ -12,11 +12,17 @@ enum class KeyboardMode {
 
 // 3. 跨平台的动作指令集 (替代 Android 的 KeyEvent)
 enum class InputAction {
-    SPACE, ENTER, BACKSPACE, DELETE_FORWARD,
+    // --- Active: used by single-swipe gestures ---
+    SPACE, ENTER, BACKSPACE,
     TOGGLE_SHIFT, TOGGLE_CAPS,
     MOVE_HOME, MOVE_END,
+
+    // --- Reserved for future use (e.g. controller / gamepad support) ---
+    // These were previously triggered by double-swipe gestures, which have been removed.
+    // Retained here so platform delegates can still handle them when needed.
     DPAD_UP, DPAD_DOWN, DPAD_LEFT, DPAD_RIGHT,
-    PAGE_UP, PAGE_DOWN, TAB
+    PAGE_UP, PAGE_DOWN,
+    TAB, DELETE_FORWARD
 }
 
 // 4. 终极"遥控器"接口！Android 和 iOS 必须实现它

--- a/android/shared/src/commonMain/kotlin/KeyboardLogic.kt
+++ b/android/shared/src/commonMain/kotlin/KeyboardLogic.kt
@@ -83,18 +83,4 @@ class KeyboardLogic {
             else -> null
         }
     }
-
-    fun getDoubleSwipeAction(dir: Direction): InputAction? {
-        return when (dir) {
-            Direction.N  -> InputAction.DPAD_UP
-            Direction.NE -> InputAction.PAGE_UP
-            Direction.E  -> InputAction.DPAD_RIGHT
-            Direction.SE -> InputAction.PAGE_DOWN
-            Direction.S  -> InputAction.DPAD_DOWN
-            Direction.SW -> InputAction.DELETE_FORWARD
-            Direction.W  -> InputAction.DPAD_LEFT
-            Direction.NW -> InputAction.TAB
-            else -> null
-        }
-    }
 }

--- a/android/shared/src/commonMain/kotlin/KeyboardStateMachine.kt
+++ b/android/shared/src/commonMain/kotlin/KeyboardStateMachine.kt
@@ -1,15 +1,12 @@
 package com.vatoo.erick.shared
 
-import kotlinx.coroutines.*
 import kotlin.math.hypot
 
 class KeyboardStateMachine(
-    private val delegate: KeyboardActionDelegate,
-    private val coroutineScope: CoroutineScope // 由 Android/iOS 传入的生命周期作用域
+    private val delegate: KeyboardActionDelegate
 ) {
     private val processor = KeyboardLogic()
     private val DEADZONE_RADIUS = 40f
-    private val DOUBLE_SWIPE_TIMEOUT = 250L
 
     // 核心状态
     private var leftActiveDir = Direction.NONE
@@ -17,11 +14,6 @@ class KeyboardStateMachine(
     private var currentMode = KeyboardMode.NORMAL
     private var isChordExecuted = false
 
-    // 协程计时器任务
-    private var singleSwipeJob: Job? = null
-    private var pendingRightDir = Direction.NONE
-
-    // 接收来自原生平台的触摸更新
     fun handleTouch(x: Float, y: Float, isLeft: Boolean, actionDownOrMove: Boolean, actionUp: Boolean) {
         val distance = hypot(x.toDouble(), y.toDouble()).toFloat()
         val currentDir = if (distance > DEADZONE_RADIUS) {
@@ -47,14 +39,12 @@ class KeyboardStateMachine(
                 rightActiveDir = Direction.NONE
             }
 
-            // 解锁
             if (leftActiveDir == Direction.NONE && rightActiveDir == Direction.NONE) {
                 isChordExecuted = false
             }
         }
     }
 
-    // 获取用于 UI 渲染的实时预览字符
     fun getPreviewText(): String {
         return if (leftActiveDir != Direction.NONE && rightActiveDir != Direction.NONE) {
             processor.getChordResult(leftActiveDir, rightActiveDir, currentMode)
@@ -69,7 +59,7 @@ class KeyboardStateMachine(
 
         val text = processor.getChordResult(left, right, currentMode)
         if (text.isNotEmpty()) {
-            delegate.commitText(text) // 呼叫代理上屏！
+            delegate.commitText(text)
         }
 
         if (currentMode == KeyboardMode.SHIFTED) {
@@ -79,30 +69,7 @@ class KeyboardStateMachine(
 
     private fun handleRightOnlySwipe(dir: Direction) {
         if (dir == Direction.NONE) return
-
-        if (pendingRightDir == dir && singleSwipeJob?.isActive == true) {
-            // 触发双击
-            singleSwipeJob?.cancel()
-            pendingRightDir = Direction.NONE
-
-            val action = processor.getDoubleSwipeAction(dir)
-            if (action != null) delegate.sendInputAction(action)
-        } else {
-            // 防御异向连滑漏洞
-            if (singleSwipeJob?.isActive == true) {
-                singleSwipeJob?.cancel()
-                executeSingleSwipe(pendingRightDir)
-            }
-
-            pendingRightDir = dir
-            // 启动协程计时器
-            singleSwipeJob = coroutineScope.launch {
-                delay(DOUBLE_SWIPE_TIMEOUT)
-                // 如果倒计时结束还没被取消，触发单击
-                executeSingleSwipe(dir)
-                pendingRightDir = Direction.NONE
-            }
-        }
+        executeSingleSwipe(dir)
     }
 
     private fun executeSingleSwipe(dir: Direction) {
@@ -112,22 +79,22 @@ class KeyboardStateMachine(
             is InputAction -> {
                 when (result) {
                     InputAction.TOGGLE_SHIFT -> currentMode = if (currentMode == KeyboardMode.NORMAL) KeyboardMode.SHIFTED else KeyboardMode.NORMAL
-                    InputAction.TOGGLE_CAPS -> currentMode = if (currentMode == KeyboardMode.CAPS_LOCKED) KeyboardMode.NORMAL else KeyboardMode.CAPS_LOCKED
-                    else -> delegate.sendInputAction(result) // 交给原生平台处理回车、退格等
+                    InputAction.TOGGLE_CAPS  -> currentMode = if (currentMode == KeyboardMode.CAPS_LOCKED) KeyboardMode.NORMAL else KeyboardMode.CAPS_LOCKED
+                    else -> delegate.sendInputAction(result)
                 }
             }
         }
     }
-    // 专门为 iOS 准备的无痛初始化工厂函数
-    fun createKeyboardStateMachineForIOS(delegate: KeyboardActionDelegate): KeyboardStateMachine {
-        // 自动在 Kotlin 端创建一个绑定主线程的作用域供 iOS 使用
-        return KeyboardStateMachine(delegate, kotlinx.coroutines.MainScope())
-    }
 }
-// Kotlin 的 object 关键字相当于全局单例
+
+// 专门为 iOS 准备的无痛初始化工厂函数
+fun createKeyboardStateMachineForIOS(delegate: KeyboardActionDelegate): KeyboardStateMachine {
+    // 自动在 Kotlin 端创建一个绑定主线程的作用域供 iOS 使用
+    return KeyboardStateMachine(delegate)
+}
+
 object KeyboardFactory {
     fun createEngine(delegate: KeyboardActionDelegate): KeyboardStateMachine {
-        // 我们在兵工厂内部，悄悄把 iOS 不懂的协程作用域给装配好
-        return KeyboardStateMachine(delegate, kotlinx.coroutines.MainScope())
+        return KeyboardStateMachine(delegate)
     }
 }


### PR DESCRIPTION
This pull request refactors the Android input method service and shared keyboard logic to remove coroutine-based double-swipe gesture handling, simplify state management, and clarify the `InputAction` enum. The changes streamline the codebase, improve maintainability, and prepare for future platform support by retaining relevant action definitions.

**Removal of coroutine-based double-swipe gesture handling:**
* Eliminated coroutine scope and job management from `MyInputMethodService`, including lifecycle overrides and related member variables. The `KeyboardStateMachine` no longer requires a coroutine scope, and all coroutine logic for gesture timing has been removed.
* Removed the double-swipe gesture detection and associated coroutine timer logic from `KeyboardLogic` and `KeyboardStateMachine`, including the `getDoubleSwipeAction` method and its invocation. 

**Code and enum simplification:**
* Clarified and reorganized the `InputAction` enum to distinguish active actions from reserved ones, and retained previously double-swipe-triggered actions for future platform support.
* Updated logic in `MyInputMethodService` to handle `InputAction` values consistently, including the handling of shift and caps actions and removal of redundant comments.

**API and initialization changes:**
* Refactored the initialization of `KeyboardStateMachine` and related factory methods to remove coroutine scope requirements, simplifying cross-platform instantiation.

These changes collectively reduce complexity, remove unused gesture features, and make the codebase easier to maintain and extend. Closes #8 